### PR TITLE
Gadget updates

### DIFF
--- a/censeye/cli.py
+++ b/censeye/cli.py
@@ -325,6 +325,9 @@ async def run_censeye(
     multiple=True,
     help="list of gadgets to load",
 )
+@click.option(
+    "--list-gadgets", is_flag=True, help="list available gadgets"
+)
 @click.version_option(__version__)
 def main(
     ip,
@@ -344,8 +347,8 @@ def main(
     fast,
     slow,
     gadget,
+    list_gadgets,
 ):
-
     if sum([fast, slow]) > 1:
         print("Only one of --fast or --slow can be set.")
         sys.exit(1)
@@ -412,6 +415,18 @@ def main(
         )
 
     console = Console(record=True, soft_wrap=True)
+
+    if list_gadgets:
+        table = Table(title="available gadgets", box=box.MINIMAL_DOUBLE_HEAD)
+        table.add_column("name", no_wrap=True)
+        table.add_column("aliases", no_wrap=True)
+        table.add_column("desc", no_wrap=False)
+
+        for name, g in unarmed_gadgets.items():
+            table.add_row(f"[bold]{name}[/bold]", f"[i]{', '.join(g.aliases)}[/i]", g.__doc__)
+
+        console.print(table)
+        sys.exit(0)
 
     async def _run_worker(queue):
         while not queue.empty():

--- a/censeye/config.py
+++ b/censeye/config.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import yaml
 
+from .gadgets import unarmed_gadgets
+
 IgnoreType = Optional[Union[List[str], List[Dict[str, List[str]]]]]
 
 
@@ -29,7 +31,7 @@ class Field:
 class Gadget:
     name: str
     config: Dict[str, Any]
-    short_name: str = ""
+    aliases: List[str] = field(default_factory=list)
     enabled: bool = False
 
     def __hash__(self) -> int:
@@ -84,7 +86,7 @@ class Gadgets:
 
     def enable(self, name: str):
         for _gadget in self.gadgets:
-            if _gadget.name == name or _gadget.short_name == name:
+            if _gadget.name == name or name in _gadget.aliases:
                 _gadget.enabled = True
                 return
 
@@ -92,7 +94,7 @@ class Gadgets:
 
     def disable(self, name: str):
         for _gadget in self.gadgets:
-            if _gadget.name == name:
+            if _gadget.name == name or name in _gadget.aliases:
                 _gadget.enabled = False
                 return
 
@@ -128,25 +130,23 @@ class Config:
         self.min_host_count = 2
         self.max_host_count = 120
         self.min_pivot_weight = 0.0
+        self.gadgets = Gadgets()
 
-        self.gadgets = Gadgets(
-            [
-                Gadget(name="open-directory", config={"max_files": 32, "min_chars": 1}),
-                Gadget(name="nobbler", config={"iterations": [4, 8, 16, 32]}),
-                Gadget(name="virustotal", config={}, short_name="vt", enabled=False),
-                Gadget(name="threatfox", config={}, short_name="tf", enabled=False),
-            ]
-        )
+        for name, gadget in unarmed_gadgets.items():
+            self.gadgets.append(
+                Gadget(
+                    name=name,
+                    aliases=gadget.aliases,
+                    config=gadget.config,
+                    enabled=False,
+                )
+            )
 
         self.fields = [
-            Field(
-                name="virus-total.gadget.censeye", weight=1.0, ignore=[]),
-            Field(
-                name="open-directory.gadget.censeye", weight=1.0, ignore=[]
-            ),  # for the opendirectory gadget
-            Field(
-                name="nobbler.gadget.censeye", weight=0.8, ignore=[]
-            ),  # for the byte-nobbler gadget
+            # Field definitions for the query generator gadgets (if enabled), so we can use them for pivots
+            Field(name="open-directory.gadget.censeye", weight=1.0, ignore=[]),
+            Field(name="nobbler.gadget.censeye", weight=0.8, ignore=[]),
+            # Field definitions for the search results
             Field(name="services.banner_hex", weight=1.0, ignore=[]),
             Field(name="services.ssh.endpoint_id.raw", weight=0.9, ignore=[]),
             Field(
@@ -357,12 +357,22 @@ class Config:
                 weight=0.1,
                 ignore=[],
             ),
+            Field(name="services.cobalt_strike.x86.watermark", weight=1.0, ignore=[]),
+            Field(name="services.cobalt_strike.x86.public_key", weight=1.0, ignore=[]),
             Field(name="services.cobalt_strike.x86.post_ex.x86", weight=0.1, ignore=[]),
             Field(name="services.cobalt_strike.x86.post_ex.x64", weight=0.1, ignore=[]),
             Field(
                 name="services.cobalt_strike.x86.http_post.uri", weight=1.0, ignore=[]
             ),
             Field(name="services.cobalt_strike.x86.user_agent", weight=1.0, ignore=[]),
+            Field(name="services.cobalt_strike.x64.watermark", weight=1.0, ignore=[]),
+            Field(name="services.cobalt_strike.x64.public_key", weight=1.0, ignore=[]),
+            Field(name="services.cobalt_strike.x64.post_ex.x86", weight=0.1, ignore=[]),
+            Field(name="services.cobalt_strike.x64.post_ex.x64", weight=0.1, ignore=[]),
+            Field(
+                name="services.cobalt_strike.x64.http_post.uri", weight=1.0, ignore=[]
+            ),
+            Field(name="services.cobalt_strike.x64.user_agent", weight=1.0, ignore=[]),
             Field(
                 name="services.cwmp.http_info.favicons.md5_hash", weight=0.5, ignore=[]
             ),
@@ -513,9 +523,17 @@ class Config:
         if "gadgets" in cfg:
             self.gadgets = Gadgets()
             for item in cfg["gadgets"]:
+                name = item["gadget"]
+
+                if name not in unarmed_gadgets:
+                    raise ValueError(f"Gadget {name} not found")
+
+                base = unarmed_gadgets[name]
+
                 self.gadgets.append(
                     Gadget(
-                        name=item["gadget"],
+                        name=base.long_name,
+                        short_name=base.short_name,
                         config=item.get("config", {}),
                         enabled=item.get("enabled", False),
                     )

--- a/censeye/gadget.py
+++ b/censeye/gadget.py
@@ -9,8 +9,8 @@ GADGET_NAMESPACE = "gadget.censeye"
 
 
 class Gadget(ABC):
-    short_name: str
-    long_name: str | None
+    name: str
+    aliases: list[str]
     cache_dir: str
     config: Dict[str, Any] = {}
 
@@ -18,12 +18,12 @@ class Gadget(ABC):
 
     def __init__(
         self,
-        short_name: str,
-        long_name: str | None = None,
+        name: str,
+        aliases: list[str] = [],
         config: Dict[str, Any] = {},
     ):
-        self.short_name = short_name
-        self.long_name = long_name
+        self.name = name
+        self.aliases = aliases
         self.cache_dir = self.get_cache_dir()
         self.config = config
 
@@ -34,12 +34,11 @@ class Gadget(ABC):
     def set_config(self, config: Dict[str, Any] | None) -> None:
         self.config = config or self.config
 
-    # Helper methods
     def get_env(self, key: str, default=None):
         return os.getenv(key, default)
 
     def get_cache_dir(self) -> str:
-        cache_dir = user_cache_dir(f"censys/{self.short_name}")
+        cache_dir = user_cache_dir(f"censys/{self.name}")
         os.makedirs(cache_dir, exist_ok=True)
         return cache_dir
 
@@ -58,7 +57,7 @@ class Gadget(ABC):
             json.dump(data, f)
 
     def __str__(self) -> str:
-        return f"{self.__class__.__name__}({self.short_name})"
+        return f"{self.__class__.__name__}({self.name})"
 
     def __repr__(self) -> str:
         return str(self)

--- a/censeye/gadgets/__init__.py
+++ b/censeye/gadgets/__init__.py
@@ -11,9 +11,7 @@ def load_gadgets() -> dict[str, Gadget]:
             continue
         module = importlib.import_module(f"censeye.gadgets.{file.stem}")
         gadget: Gadget = module.__gadget__
-        gadgets[gadget.short_name] = gadget
-        if gadget.long_name:
-            gadgets[gadget.long_name] = gadget
+        gadgets[gadget.name] = gadget
     return gadgets
 
 

--- a/censeye/gadgets/nobbler.py
+++ b/censeye/gadgets/nobbler.py
@@ -2,19 +2,25 @@ from censeye.gadget import QueryGeneratorGadget
 
 
 class NobblerGadget(QueryGeneratorGadget):
-    """
-    When we see UNKNOWN service types it means Censys couldn't detect the underlying protocol, but
-    recv'd some data from the service. Sometimes this data is some binary encoded format that has
-    a specific structure to it, but simply searching for the entirety of the response may not net
-    the best results, so this gadget will generate queries that search for the first N bytes of the
-    response. This is useful for protocols that have a fixed header, or a specific magic number at the
-    beginning of the response.
+    """When the service_name is UNKNOWN, it is often more effective to search the first N bytes of the response rather than analyzing the entire response.
 
-    "If a nibble is to bits, then a nobble is to bytes." - Aristotle
+Many services include a fixed header or a "magic number" at the beginning of their responses, followed by dynamic data at a later offset. This feature generates queries that focus on the initial N bytes of the response at various offsets while using wildcards for the remaining data.
+
+The goal is to make the search more generalizable: analyzing the full UNKNOWN response might only match a specific host, whereas examining just the initial N bytes is likely to match similar services across multiple hosts.
+
+Configuration:
+ - iterations: A list of integers specifying the number of bytes to examine at the start of the response.
+ - default: [4, 8, 16, 32]
+   - services.banner_hex=XXXXXXXX*
+   - services.banner_hex=XXXXXXXXXXXXXXXX*
+   - services.banner_hex=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX*
+   - services.banner_hex=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX*
+
+"If a nibble is to bits, then a nobble is to bytes." - Aristotle
     """
 
     def __init__(self):
-        super().__init__("nblr", "nobbler")
+        super().__init__("nobbler", aliases=["nob", "nblr"])
         self.config["iterations"] = [4, 8, 16, 32]
 
     def generate_query(self, host: dict) -> set[tuple[str, str]] | None:

--- a/censeye/gadgets/opendir.py
+++ b/censeye/gadgets/opendir.py
@@ -3,12 +3,19 @@ from censeye.gadget import QueryGeneratorGadget
 
 
 class OpenDirectoryGadget(QueryGeneratorGadget):
-    """
-    This gadget generates queries based on the files found in an open directory.
-    """
+    """When a service is found with an open directory listing, this gadget will attempt to parse out the file names from the HTTP response body and generate queries for each file found.
+
+This is useful for finding additional hosts with the same specific files.
+
+Configuration
+ - max_files: The maximum number of files to generate queries for.
+   default: 32
+ - min_chars: The minimum number of characters a file name must have to be considered.
+   default: 2
+"""
 
     def __init__(self):
-        super().__init__("odir", "open-directory")
+        super().__init__("open-directory", aliases=["odir", "open-dir"])
 
         self.config["max_files"] = 32
         self.config["min_chars"] = 2

--- a/censeye/gadgets/threatfox.py
+++ b/censeye/gadgets/threatfox.py
@@ -136,8 +136,10 @@ class ThreatFoxClient:
 
 
 class ThreatFoxGadget(HostLabelerGadget):
+    """Gadget to label hosts that are present in ThreatFox."""
+
     def __init__(self):
-        super().__init__("tf", "threatfox")
+        super().__init__("threatfox", aliases=["tf"])
         self.api_key = self.get_env("THREATFOX_API_KEY")
 
     def label_host(self, host: dict) -> None:

--- a/censeye/gadgets/vt.py
+++ b/censeye/gadgets/vt.py
@@ -4,8 +4,6 @@ from censeye.gadget import HostLabelerGadget
 
 
 class VT:
-    """silly little VT client"""
-
     def __init__(self, key):
         self.key = key
 
@@ -20,8 +18,13 @@ class VT:
 
 
 class VTGadget(HostLabelerGadget):
+    """A simple VirusTotal API client which will label the host if it is found to be malicious.
+
+    Configuration:
+     - VT_API_KEY: *ENVVAR* VirusTotal API key
+    """
     def __init__(self):
-        super().__init__("vt", "virustotal")
+        super().__init__("virustotal", aliases=["vt"])
         self.api_key = self.get_env("VT_API_KEY")
 
     def is_malicious(self, response: dict):
@@ -47,7 +50,6 @@ class VTGadget(HostLabelerGadget):
             response = vt.fetch_ip(ip)
             self.save_json(cache_file, response)
 
-        # Check if the host is malicious
         if self.is_malicious(response):
             self.add_label(
                 host,

--- a/config.yaml
+++ b/config.yaml
@@ -194,6 +194,10 @@ fields:
     weight: 0.0
   - field: services.parsed.chromecast.applications.display_name
     weight: 0.1
+  - field: services.cobalt_strike.x86.watermark
+    weight: 1.0
+  - field: services.cobalt_strike.x86.public_key
+    weight: 1.0
   - field: services.cobalt_strike.x86.post_ex.x86
     weight: 0.1
   - field: services.cobalt_strike.x86.post_ex.x64
@@ -201,6 +205,18 @@ fields:
   - field: services.cobalt_strike.x86.http_post.uri
     weight: 1.0
   - field: services.cobalt_strike.x86.user_agent
+    weight: 1.0
+  - field: services.cobalt_strike.x64.watermark
+    weight: 1.0
+  - field: services.cobalt_strike.x64.public_key
+    weight: 1.0
+  - field: services.cobalt_strike.x64.post_ex.x86
+    weight: 0.1
+  - field: services.cobalt_strike.x64.post_ex.x64
+    weight: 0.1
+  - field: services.cobalt_strike.x64.http_post.uri
+    weight: 1.0
+  - field: services.cobalt_strike.x64.user_agent
     weight: 1.0
   - field: services.cwmp.http_info.favicons.md5_hash
     weight: 0.5


### PR DESCRIPTION
Please let me know what you think of these minor changes.

- Gadgets no longer have a `long_name` and `short_name`; it has been changed to just `name` and `aliases.`
- The gadget alias lookups are done on the cli side instead of on the API side.
- Added a `--list-gadgets` option, which displays a table of each gadget and its underlying documentation.
